### PR TITLE
Update Node.js engine version in package-lock.json

### DIFF
--- a/siitec/package-lock.json
+++ b/siitec/package-lock.json
@@ -140,7 +140,7 @@
         "semver": "^6.3.1"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+         "node": "24.x"
       },
       "peerDependencies": {
         "@babel/core": "^7.11.0",


### PR DESCRIPTION
Changed the required Node.js engine version to 24.x in package-lock.json to ensure compatibility with the latest Node.js release.